### PR TITLE
Change: overhaul args

### DIFF
--- a/nay/args.py
+++ b/nay/args.py
@@ -93,9 +93,8 @@ class Args(dict):
             operation = [opt for opt in sys.argv[1] if opt.isupper()]
             options = [opt for opt in sys.argv[1] if opt.islower()]
         else:
-            args = sys.argv[1:]
-            operation = "N"
-            options = []
+            super().__init__({"operation": "N", "options": [], "args": sys.argv[1:]})
+            return
 
         try:
             if len(operation) > 1:

--- a/nay/args.py
+++ b/nay/args.py
@@ -86,9 +86,8 @@ class Args(dict):
 
     def __init__(self) -> None:
         if len(sys.argv) == 1:
-            args = []
-            operation = "N"
-            options = []
+            super().__init__({"operation": "N", "options": [], "args": []})
+            return
         elif sys.argv[1].startswith("-"):
             args = sys.argv[2:]
             operation = [opt for opt in sys.argv[1] if opt.isupper()]

--- a/nay/args.py
+++ b/nay/args.py
@@ -1,4 +1,3 @@
-import getopt
 import sys
 
 from . import operations
@@ -170,6 +169,8 @@ class Args(dict):
                         options.append(opt)
                     else:
                         options.append(valid_opts[opt])
+        else:
+            options = _options
 
         super().__init__(
             {

--- a/nay/args.py
+++ b/nay/args.py
@@ -1,3 +1,4 @@
+import getopt
 import sys
 
 from . import operations
@@ -61,45 +62,45 @@ class Args(dict):
     """
 
     OPERATIONS = {
-        "sync": {
-            "short": "S",
+        "--sync": {
+            "short": "-S",
             "operation": operations.Sync,
             "options": {
-                "y": {"conflicts": [], "long": "refresh", "stacks": 2},
-                "u": {"conflicts": ["s"], "long": "sysupgrade", "stacks": 1},
-                "s": {"conflicts": ["u", "w"], "long": "search", "stacks": 1},
-                "w": {"conflicts": ["i", "s"], "long": "downloadonly", "stacks": 1},
-                "i": {"conflicts": ["w", "s"], "long": "info", "stacks": 1},
-                "c": {"conflicts": [], "long": "clean", "stacks": 1},
+                "--refresh": {"conflicts": [], "short": "-y"},
+                "--sysupgrade": {"conflicts": ["s"], "short": "-u"},
+                "--search": {"conflicts": ["u", "w"], "short": "-s"},
+                "--downloadonly": {"conflicts": ["i", "s"], "short": "-w"},
+                "--info": {"conflicts": ["w", "s"], "short": "-i"},
+                "--clean": {"conflicts": [], "short": "-c"},
             },
             "pure_wrapper": False,
         },
-        "getpkgbuild": {
-            "short": "G",
+        "--getpkgbuild": {
+            "short": "-G",
             "operation": operations.GetPKGBUILD,
             "options": {},
             "pure_wrapper": False,
         },
-        "nay": {
-            "short": "N",
+        "--nay": {
+            "short": "-N",
             "operation": operations.Nay,
             "options": {},
             "pure_wrapper": False,
         },
-        "remove": {
-            "short": "R",
+        "--remove": {
+            "short": "-R",
             "operation": operations.Remove,
             "options": {},
             "pure_wrapper": True,
         },
-        "query": {
-            "short": "Q",
+        "--query": {
+            "short": "-Q",
             "operation": operations.Query,
             "options": {},
             "pure_wrapper": True,
         },
-        "upgrade": {
-            "short": "U",
+        "--upgrade": {
+            "short": "-U",
             "operation": operations.Upgrade,
             "options": {},
             "pure_wrapper": True,
@@ -117,86 +118,58 @@ class Args(dict):
             )
             return
 
-        else:
-            short_operations = [
-                operation[0].upper() for operation in self.OPERATIONS.keys()
-            ]
-            args = []
-            operations = []
-            options = []
-            for arg in sys.argv[1:]:
-                if arg.startswith("--"):
-                    arg = arg[2:]
-                    if arg in self.OPERATIONS.keys():
-                        operations.append(arg)
-                    else:
-                        options.append(arg)
-                elif arg.startswith("-"):
-                    arg = arg[1:]
-                    for char in arg:
-                        if char.isupper():
-                            operations.append(char)
-                        else:
-                            options.append(char)
+        operation = []
+        _options = []
+        options = []
+        args = []
+        valid_operations = [op[2:] for op in self.OPERATIONS.keys()]
+        for arg in sys.argv[1:]:
+            if arg[:2] == "--":
+                if arg in self.OPERATIONS.keys():
+                    operation.append(arg)
                 else:
-                    args.append(arg)
+                    _options.append(arg)
+            elif arg[0] == "-":
+                for flag in arg[1:]:
+                    if flag.isupper():
+                        if flag.lower() not in [op[0] for op in valid_operations]:
+                            raise InvalidOperation(f"error: invalid option -- {flag}")
+                        else:
+                            for op in valid_operations:
+                                if flag.lower() == op[0]:
+                                    operation.append(f"--{op}")
+                    else:
+                        _options.append(f"-{flag}")
+
+            else:
+                args.append(arg)
 
         try:
-            if len(operations) > 1:
+            if len(operation) > 1:
                 raise ConflictingOperations(
-                    "error: only one operation may be used at a time"
+                    f"error: only one operation may be used at a time"
                 )
-            elif len(operations) == 0:
-                operation = "nay"
-            else:
-                operation = operations[0]
-
-            if (
-                operation not in short_operations
-                and operation not in self.OPERATIONS.keys()
-            ):
-
-                raise InvalidOperation(f"nay: invalid option -- {operation}")
-
-            for valid in self.OPERATIONS.keys():
-                if operation.lower() == valid[0]:
-                    operation = valid
-                    break
-
-            if self.OPERATIONS[operation]["pure_wrapper"] == False:
-                valid_options = {}
-                for short_opt in self.OPERATIONS[operation]["options"]:
-                    valid_options[short_opt] = self.OPERATIONS[operation]["options"][
-                        short_opt
-                    ]["long"]
-                for num, opt in enumerate(options):
-                    if (
-                        opt not in valid_options.keys()
-                        and opt not in valid_options.values()
-                    ):
-                        raise InvalidOption(f"nay: invalid option '-{opt}'")
-                    else:
-                        options.pop(num)
-                        if opt in valid_options.keys():
-                            options.append(opt)
-                        else:
-                            _valid_options = {
-                                long_opt: short_opt
-                                for short_opt, long_opt in valid_options.items()
-                            }
-
-                            options.append(_valid_options[opt])
-
-                for opt in options:
-                    if any(
-                        _ in options
-                        for _ in self.OPERATIONS[operation]["options"][opt]["conflicts"]
-                    ):
-                        raise ConflictingOptions(f"error: conflicting options")
-
-        except ArgumentError as err:
+        except ConflictingOperations as err:
             print(err)
             quit()
+
+        operation = operation[0]
+
+        valid_opts = {}
+        if self.OPERATIONS[operation]["pure_wrapper"] == False:
+            for long_opt in self.OPERATIONS[operation]["options"].keys():
+                short_opt = self.OPERATIONS[operation]["options"][long_opt]["short"]
+                valid_opts[long_opt] = short_opt
+                valid_opts[short_opt] = long_opt
+
+            for opt in _options:
+                if opt not in valid_opts.keys():
+                    raise InvalidOption(f"error: invalid option '{opt}'")
+                else:
+                    if opt[:2] == "--":
+                        options.append(opt)
+                    else:
+                        options.append(valid_opts[opt])
 
         super().__init__(
             {

--- a/nay/operations.py
+++ b/nay/operations.py
@@ -168,7 +168,7 @@ class Query(Operation):
 
     def run(self) -> None:
         subprocess.run(
-            shlex.split(f"sudo pacman -Q{''.join(self.options)} {' '.join(self.args)}")
+            shlex.split(f"pacman -Q{''.join(self.options)} {' '.join(self.args)}")
         )
 
 

--- a/nay/operations.py
+++ b/nay/operations.py
@@ -81,23 +81,28 @@ class Sync(Operation):
 
     def __init__(self, options: list[str], args: list[str]) -> None:
         self.key = {
-            "y": self.refresh,
-            "u": self.upgrade,
-            "w": self.download,
-            "c": self.clean,
-            "s": self.query,
-            "i": self.info,
+            "--refresh": self.refresh,
+            "--sysupgrade": self.upgrade,
+            "--downloadonly": self.download,
+            "--clean": self.clean,
+            "--search": self.search,
+            "--info": self.info,
         }
+
+        if options.count("--refresh") > 1:
+            options.append("--refresh --refresh")
+            options = list(filter(lambda opt: opt != "--refresh", options))
+        options = list(set(options))
         super().__init__(options, args, self.run)
 
     def run(self) -> None:
         if not self.options:
-            # Add error handling for missing args here
+            # TODO: Add error handling for missing args here
             self.install()
-        elif any(opt in ["c", "s", "i"] for opt in self.options):
-            for opt in set(self.options):
+        elif any(opt in ["--clean", "--search", "--info"] for opt in self.options):
+            for opt in self.options:
                 self.key[opt]()
-        elif "w" in self.options:
+        elif "--downloadonly" in self.options:
             self.download()
         else:
             for opt in set(self.options):
@@ -105,7 +110,7 @@ class Sync(Operation):
             if self.args:
                 self.install()
 
-    def query(self) -> None:
+    def search(self) -> None:
         packages = utils.search(" ".join(self.args))
         utils.print_pkglist(packages)
 
@@ -168,7 +173,7 @@ class Query(Operation):
 
     def run(self) -> None:
         subprocess.run(
-            shlex.split(f"pacman -Q{''.join(self.options)} {' '.join(self.args)}")
+            shlex.split(f"pacman -Q {' '.join(self.options)} {' '.join(self.args)}")
         )
 
 
@@ -241,7 +246,9 @@ class Remove(Operation):
 
     def run(self) -> None:
         subprocess.run(
-            shlex.split(f"sudo pacman -R{''.join(self.options)} {' '.join(self.args)}")
+            shlex.split(
+                f"sudo pacman -R {' '.join(self.options)} {' '.join(self.args)}"
+            )
         )
 
 
@@ -266,5 +273,7 @@ class Upgrade(Operation):
 
     def run(self) -> None:
         subprocess.run(
-            shlex.split(f"sudo pacman -U {''.join(self.options)} {' '.join(self.args)}")
+            shlex.split(
+                f"sudo pacman -U {' '.join(self.options)} {' '.join(self.args)}"
+            )
         )

--- a/nay/operations.py
+++ b/nay/operations.py
@@ -82,6 +82,7 @@ class Sync(Operation):
     def __init__(self, options: list[str], args: list[str]) -> None:
         self.key = {
             "--refresh": self.refresh,
+            "--refresh --refresh": self.force_refresh,
             "--sysupgrade": self.upgrade,
             "--downloadonly": self.download,
             "--clean": self.clean,
@@ -93,6 +94,7 @@ class Sync(Operation):
             options.append("--refresh --refresh")
             options = list(filter(lambda opt: opt != "--refresh", options))
         options = list(set(options))
+        options = list(sorted(options, key=lambda x: list(self.key.keys()).index(x)))
         super().__init__(options, args, self.run)
 
     def run(self) -> None:
@@ -119,8 +121,11 @@ class Sync(Operation):
         if targets:
             utils.install(*targets)
 
-    def refresh(self, force: Optional[bool] = False) -> None:
-        utils.refresh(force=force)
+    def force_refresh(self):
+        utils.force_refresh()
+
+    def refresh(self):
+        utils.refresh()
 
     def upgrade(self) -> None:
         utils.upgrade()

--- a/nay/utils.py
+++ b/nay/utils.py
@@ -1,3 +1,4 @@
+import concurrent.futures
 import os
 import re
 import shlex
@@ -5,7 +6,6 @@ import shutil
 import subprocess
 from typing import Optional
 
-import concurrent.futures
 import networkx as nx
 import requests
 from rich.console import Group
@@ -14,8 +14,8 @@ from rich.text import Text
 
 from .config import CACHEDIR
 from .console import console
-from .db import DATABASES, SYNC_PACKAGES, INSTALLED
-from .package import Package, AURPackage, SyncPackage
+from .db import DATABASES, INSTALLED, SYNC_PACKAGES
+from .package import AURPackage, Package, SyncPackage
 
 SORT_PRIORITIES = {"db": {"core": 0, "extra": 1, "community": 2, "multilib": 4}}
 for num, db in enumerate(DATABASES):

--- a/nay/utils.py
+++ b/nay/utils.py
@@ -25,19 +25,18 @@ for num, db in enumerate(DATABASES):
 SORT_PRIORITIES["db"]["aur"] = max([num for num in SORT_PRIORITIES["db"].values()])
 
 
-def refresh(force: Optional[bool] = False) -> None:
+def refresh() -> None:
     """
     Refresh the sync database. This is a pure pacman wrapper
-
-    :param force: Optional parameter indicating whether the sync database should be refreshed even if it's flagged as up-to-date (not generally recommended). Default is False
-    :type force: Optional[bool]
-
     """
+    subprocess.run(shlex.split(f"sudo pacman -Sy"))
 
-    if force:
-        subprocess.run(shlex.split(f"sudo pacman -Syy"))
-    else:
-        subprocess.run(shlex.split(f"sudo pacman -Sy"))
+
+def force_refresh() -> None:
+    """
+    Force refresh the sync database. This is a pure pacman wrapper.
+    """
+    subprocess.run(shlex.split(f"sudo pacman -Syy"))
 
 
 def upgrade() -> None:


### PR DESCRIPTION
This PR fully overhauls the way args are parsed. nay will now accept any number of args in any order and parse them as appropriate.

The solution truly is ugly, but it works exactly as intended. This will need another overhaul in the future for sanity's sake.

The majority of the changes were to the `args` module and the `operations.Sync` object.